### PR TITLE
Externalizing the DJI Key from the code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,12 +48,9 @@ Note that if you are using QGroundControl on the same device as RosettaDrone, th
  
 3. Sign up for the DJI Developer Program at https://developer.dji.com/mobile-sdk/ and create an Application key. The package name should be sq.rogue.rosettadrone.
  
-4. Create a new file called keys.xml in the /values folder, and insert the following:
+4. Create a new file `~/.gradle/gradle.properties` if you don't have one yet, and add the following line to it:
     ```
-    <?xml version="1.0" encoding="utf-8"?>
-    <resources>
-        <string name="dji_key">INSERT KEY HERE</string>
-    </resources>
+    DJI_API_KEY_ROSETTA_DRONE=INSERT KEY HERE
     ```
     
 5. Run **Build->Make Project**

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -10,6 +10,7 @@ android {
         versionName "1.2.1"
         testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
         multiDexEnabled true
+        manifestPlaceholders = [DJIApiKey: project.properties['DJI_API_KEY_ROSETTA_DRONE']]
     }
 
     buildTypes {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,7 +52,7 @@
         <uses-library android:name="com.android.future.usb.accessory"/>
         <meta-data
             android:name="com.dji.sdk.API_KEY"
-            android:value="@string/dji_key"/>
+            android:value="${DJIApiKey}"/>
 
         <service android:name="dji.sdk.sdkmanager.DJIGlobalService">
         </service>


### PR DESCRIPTION
Adding configuration on the manifest and the build.gradle in order to read the DJI Key from the global gradle.properties. This has the advantage of not having to worry about pushing the key on the source code repo by mistake.